### PR TITLE
Chain the Flycheck checker after emacs-lisp-checkdoc

### DIFF
--- a/flycheck-package.el
+++ b/flycheck-package.el
@@ -273,7 +273,10 @@ header with any leading or trailing whitespace removed."
   "Setup flycheck-package.
 Add `flycheck-emacs-lisp-package' to `flycheck-checkers'."
   (interactive)
-  (add-to-list 'flycheck-checkers 'emacs-lisp-package))
+  (add-to-list 'flycheck-checkers 'emacs-lisp-package t)
+  (unless (memq 'emacs-lisp-package
+                (flycheck-checker-next-checkers 'emacs-lisp-checkdoc))
+    (flycheck-add-next-checker 'emacs-lisp-checkdoc 'emacs-lisp-package)))
 
 (provide 'flycheck-package)
 ;;; flycheck-package.el ends here


### PR DESCRIPTION
Fixes #9.

/cc @lunaryorn
