### PR TITLE
readme : Corrent package name in credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ for details.
 Credits
 -------
 
-`flycheck-package` was written by
+`package-lint` was written by
 [Steve Purcell](https://github.com/purcell) with significant
 contributions from [Fanael Linithien](https://github.com/Fanael).
 


### PR DESCRIPTION
The package name is package-lint, so i think the credits section should mention the same name. Probably a copy paste error?