### PR TITLE
List the valid keywords from `finder-known-keywords'

### DIFF
--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -54,7 +54,44 @@ FORCE is passed directly to `package-lint-buffer', which see."
 (ert-deftest package-lint-test-warn-nonstandard-keyword ()
   (should
    (equal
-    '((3 1 warning "\"foo\" is not a standard package keyword: see `finder-known-keywords'."))
+    '((3 1 warning "\"foo\" is not a standard package keyword, use one of the following:
+     abbrev - abbreviation handling, typing shortcuts, and macros
+        bib - bibliography processors
+          c - C and related programming languages
+   calendar - calendar and time management tools
+       comm - communications, networking, and remote file access
+convenience - convenience features for faster editing
+       data - editing data (non-text) files
+       docs - Emacs documentation facilities
+ emulations - emulations of other editors
+ extensions - Emacs Lisp language extensions
+      faces - fonts and colors for text
+      files - file editing and manipulation
+     frames - Emacs frames and window systems
+      games - games, jokes and amusements
+   hardware - interfacing with system hardware
+       help - Emacs help systems
+ hypermedia - links between text or other media types
+       i18n - internationalization and character-set support
+   internal - code for Emacs internals, build process, defaults
+  languages - specialized modes for editing programming languages
+       lisp - Lisp support, including Emacs Lisp
+      local - code local to your site
+      maint - Emacs development tools and aids
+       mail - email reading and posting
+   matching - searching, matching, and sorting
+      mouse - mouse support
+ multimedia - images and sound
+       news - USENET news reading and posting
+   outlines - hierarchical outlining and note taking
+  processes - processes, subshells, and compilation
+  terminals - text terminals (ttys)
+        tex - the TeX document formatter
+      tools - programming tools
+       unix - UNIX feature interfaces and emulators
+         vc - version control
+         wp - word processing
+"))
     (package-lint-test--run ";; Keywords: foo"))))
 
 (ert-deftest package-lint-test-warn-invalid-version ()

--- a/package-lint.el
+++ b/package-lint.el
@@ -158,6 +158,20 @@ Package-Version headers are present."
 
 ;;; Checks
 
+(defun package-lint--list-known-keywords ()
+  "List the known valid keywords for for the Keyword header.
+Takes the keywords from `finder-known-keywords' and formats them for displaying."
+  (let ((good-known-keywords finder-known-keywords)
+	(formatted-valid-keywords ""))
+    (while good-known-keywords
+      (setq formatted-valid-keywords
+	    (concat formatted-valid-keywords
+		    (format "%11s - %s\n"
+			    (caar good-known-keywords)
+			    (cdr (car good-known-keywords)))))
+      (setq good-known-keywords (cdr good-known-keywords)))
+    formatted-valid-keywords))
+
 (defun package-lint--check-keywords-list ()
   "Verify that package keywords are listed in `finder-known-keywords'."
   (when (package-lint--goto-header "Keywords")
@@ -167,7 +181,9 @@ Package-Version headers are present."
         (unless (assoc (intern keyword) finder-known-keywords)
           (package-lint--error
            line-no 1 'warning
-           (format "\"%s\" is not a standard package keyword: see `finder-known-keywords'." keyword)))))))
+	   (format "\"%s\" is not a standard package keyword, use one of the following:\n%s"
+	   	   keyword
+	   	   (package-lint--list-known-keywords))))))))
 
 (defun package-lint--check-dependency-list ()
   "Check the contents of the \"Package-Requires\" header.


### PR DESCRIPTION
The function for pointing out the invalid keywords used to send the user
to look up the valid keywords from `finder-known-keywords'. But why have
this extra step, why not just tell the user what the valid keywords are?

This is my attempt at doing just that, pointing out the invalid keyword
and then listing the valid keywords that the user can chose from in
order to pass the linting.