### PR TITLE
List the valid keywords

### DIFF
--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -54,45 +54,8 @@ FORCE is passed directly to `package-lint-buffer', which see."
 (ert-deftest package-lint-test-warn-nonstandard-keyword ()
   (should
    (equal
-    '((3 1 warning "\"foo\" is not a standard package keyword, use one of the following:
-     abbrev - abbreviation handling, typing shortcuts, and macros
-        bib - bibliography processors
-          c - C and related programming languages
-   calendar - calendar and time management tools
-       comm - communications, networking, and remote file access
-convenience - convenience features for faster editing
-       data - editing data (non-text) files
-       docs - Emacs documentation facilities
- emulations - emulations of other editors
- extensions - Emacs Lisp language extensions
-      faces - fonts and colors for text
-      files - file editing and manipulation
-     frames - Emacs frames and window systems
-      games - games, jokes and amusements
-   hardware - interfacing with system hardware
-       help - Emacs help systems
- hypermedia - links between text or other media types
-       i18n - internationalization and character-set support
-   internal - code for Emacs internals, build process, defaults
-  languages - specialized modes for editing programming languages
-       lisp - Lisp support, including Emacs Lisp
-      local - code local to your site
-      maint - Emacs development tools and aids
-       mail - email reading and posting
-   matching - searching, matching, and sorting
-      mouse - mouse support
- multimedia - images and sound
-       news - USENET news reading and posting
-   outlines - hierarchical outlining and note taking
-  processes - processes, subshells, and compilation
-  terminals - text terminals (ttys)
-        tex - the TeX document formatter
-      tools - programming tools
-       unix - UNIX feature interfaces and emulators
-         vc - version control
-         wp - word processing
-"))
-    (package-lint-test--run ";; Keywords: foo"))))
+    '((3 1 warning "\"foo\" is not a standard package keyword, use one of the following: abbrev, bib, c, calendar, comm, convenience, data, docs, emulations, extensions, faces, files, frames, games, hardware, help, hypermedia, i18n, internal, languages, lisp, local, maint, mail, matching, mouse, multimedia, news, outlines, processes, terminals, tex, tools, unix, vc, wp."))
+   (package-lint-test--run ";; Keywords: foo"))))
 
 (ert-deftest package-lint-test-warn-invalid-version ()
   (should

--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -54,7 +54,44 @@ FORCE is passed directly to `package-lint-buffer', which see."
 (ert-deftest package-lint-test-warn-nonstandard-keyword ()
   (should
    (equal
-    '((3 1 warning "\"foo\" is not a standard package keyword: see `finder-known-keywords'."))
+    '((3 1 warning "\"foo\" is not a standard package keyword, use one of the following:
+     abbrev - abbreviation handling, typing shortcuts, and macros
+        bib - bibliography processors
+          c - C and related programming languages
+   calendar - calendar and time management tools
+       comm - communications, networking, and remote file access
+convenience - convenience features for faster editing
+       data - editing data (non-text) files
+       docs - Emacs documentation facilities
+ emulations - emulations of other editors
+ extensions - Emacs Lisp language extensions
+      faces - fonts and colors for text
+      files - file editing and manipulation
+     frames - Emacs frames and window systems
+      games - games, jokes and amusements
+   hardware - interfacing with system hardware
+       help - Emacs help systems
+ hypermedia - links between text or other media types
+       i18n - internationalization and character-set support
+   internal - code for Emacs internals, build process, defaults
+  languages - specialized modes for editing programming languages
+       lisp - Lisp support, including Emacs Lisp
+      local - code local to your site
+      maint - Emacs development tools and aids
+       mail - email reading and posting
+   matching - searching, matching, and sorting
+      mouse - mouse support
+ multimedia - images and sound
+       news - USENET news reading and posting
+   outlines - hierarchical outlining and note taking
+  processes - processes, subshells, and compilation
+  terminals - text terminals (ttys)
+        tex - the TeX document formatter
+      tools - programming tools
+       unix - UNIX feature interfaces and emulators
+         vc - version control
+         wp - word processing
+"))
     (package-lint-test--run ";; Keywords: foo"))))
 
 (ert-deftest package-lint-test-warn-invalid-version ()

--- a/package-lint.el
+++ b/package-lint.el
@@ -158,6 +158,20 @@ Package-Version headers are present."
 
 ;;; Checks
 
+(defun package-lint--list-known-keywords ()
+  "List the known valid keywords for for the Keyword header.
+Takes the keywords from `finder-known-keywords' and formats them for displaying."
+  (let ((good-known-keywords finder-known-keywords)
+	(formatted-valid-keywords ""))
+    (while good-known-keywords
+      (setq formatted-valid-keywords
+	    (concat formatted-valid-keywords
+		    (format "%11s - %s\n"
+			    (caar good-known-keywords)
+			    (cdr (car good-known-keywords)))))
+      (setq good-known-keywords (cdr good-known-keywords)))
+    formatted-valid-keywords))
+
 (defun package-lint--check-keywords-list ()
   "Verify that package keywords are listed in `finder-known-keywords'."
   (when (package-lint--goto-header "Keywords")
@@ -167,7 +181,9 @@ Package-Version headers are present."
         (unless (assoc (intern keyword) finder-known-keywords)
           (package-lint--error
            line-no 1 'warning
-           (format "\"%s\" is not a standard package keyword: see `finder-known-keywords'." keyword)))))))
+	   (format "\"%s\" is not a standard package keyword, use one of the following:\n%s"
+	   	   keyword
+	   	   (package-lint--list-known-keywords))))))))
 
 (defun package-lint--check-dependency-list ()
   "Check the contents of the \"Package-Requires\" header.

--- a/package-lint.el
+++ b/package-lint.el
@@ -161,16 +161,10 @@ Package-Version headers are present."
 (defun package-lint--list-known-keywords ()
   "List the known valid keywords for for the Keyword header.
 Takes the keywords from `finder-known-keywords' and formats them for displaying."
-  (let ((good-known-keywords finder-known-keywords)
-	(formatted-valid-keywords ""))
-    (while good-known-keywords
-      (setq formatted-valid-keywords
-	    (concat formatted-valid-keywords
-		    (format "%11s - %s\n"
-			    (caar good-known-keywords)
-			    (cdr (car good-known-keywords)))))
-      (setq good-known-keywords (cdr good-known-keywords)))
-    formatted-valid-keywords))
+  (mapconcat
+   (lambda (valid-keyword)
+     (format "%11s - %s\n" (car valid-keyword) (cdr valid-keyword)))
+   finder-known-keywords ""))
 
 (defun package-lint--check-keywords-list ()
   "Verify that package keywords are listed in `finder-known-keywords'."

--- a/package-lint.el
+++ b/package-lint.el
@@ -161,10 +161,9 @@ Package-Version headers are present."
 (defun package-lint--list-known-keywords ()
   "List the known valid keywords for for the Keyword header.
 Takes the keywords from `finder-known-keywords' and formats them for displaying."
-  (replace-regexp-in-string ", $" "."
-			    (mapconcat
-			     (lambda (valid-keyword)
-			       (format "%s, " (car valid-keyword))) finder-known-keywords "")))
+  (mapconcat
+   (lambda (valid-keyword)
+     (format "%s, " (car valid-keyword))) finder-known-keywords ""))
 
 (defun package-lint--check-keywords-list ()
   "Verify that package keywords are listed in `finder-known-keywords'."

--- a/package-lint.el
+++ b/package-lint.el
@@ -161,10 +161,10 @@ Package-Version headers are present."
 (defun package-lint--list-known-keywords ()
   "List the known valid keywords for for the Keyword header.
 Takes the keywords from `finder-known-keywords' and formats them for displaying."
-  (mapconcat
-   (lambda (valid-keyword)
-     (format "%11s - %s\n" (car valid-keyword) (cdr valid-keyword)))
-   finder-known-keywords ""))
+  (replace-regexp-in-string ", $" "."
+			    (mapconcat
+			     (lambda (valid-keyword)
+			       (format "%s, " (car valid-keyword))) finder-known-keywords "")))
 
 (defun package-lint--check-keywords-list ()
   "Verify that package keywords are listed in `finder-known-keywords'."
@@ -175,7 +175,7 @@ Takes the keywords from `finder-known-keywords' and formats them for displaying.
         (unless (assoc (intern keyword) finder-known-keywords)
           (package-lint--error
            line-no 1 'warning
-	   (format "\"%s\" is not a standard package keyword, use one of the following:\n%s"
+	   (format "\"%s\" is not a standard package keyword, use one of the following: %s"
 	   	   keyword
 	   	   (package-lint--list-known-keywords))))))))
 


### PR DESCRIPTION
This PR is built on top of this PR discussion: https://github.com/purcell/package-lint/pull/43

It lists the valid keywords when an invalid keyword is detected.

Yes, the PR can't be merged, but I'm looking for comments if the warning message is valid.

Thank you