### PR TITLE
Lint always, even in absence of Version and Package-Requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,6 @@ This library provides a linter for the metadata in Emacs Lisp files
 which are intended to be packages. You can integrate it into your
 build process.
 
-Currently these checks are only activated if a `Package-Requires` or
-`Package-Version` header is present in the file, or if non-nil `force`
-is passed to `package-lint-buffer`, and checks center on the validity of
-the data in that header.
-
 See [flycheck-package](https://github.com/purcell/flycheck-package),
 which uses this code to conveniently display packaging errors while
 writing elisp packages. This code was extracted from


### PR DESCRIPTION
The idea is that there's no point in calling package-lint when linting is not desired in the first place.

Additionally, expose a predicate that checks if a buffer looks like a package so that automated linting tools like flycheck-package can keep their old behavior.

---

@purcell, can you rebase it onto master when purcell/flycheck-package#2 is merged?