### PR TITLE
Ignore list elements returns by imenu if they are comments

### DIFF
--- a/package-lint.el
+++ b/package-lint.el
@@ -626,7 +626,11 @@ The returned list is of the form (SYMBOL-NAME . POSITION)."
          (when (member submenu-name '("Variables" "Defuns"))
            (setq result (nconc (reverse submenu-elements) result))))
         (_
-         (push entry result))))
+         (unless (and (consp entry)     ;Do not push entry to result if it's a comment
+                      (save-excursion
+                        (goto-char (cdr entry))
+                        (looking-at-p ";+")))
+           (push entry result)))))
     ;; If it's Semantic, then it returns overlays, not positions. Convert
     ;; them.
     (dolist (entry result)


### PR DESCRIPTION
Users can have imenu set up to list comment headers like

    ;;; Section 1
    ;;;; Section 1.1

Before this patch, "Section 1" and "Section 1.1" were considered as
"variable/function definitions" as per `package-lint--get-defs`.

After this patch, such comment lines are not returned by the variable/function
def list returned by that function.