### PR TITLE
Note that MELPA strictly requires hyphen separators

### DIFF
--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -197,8 +197,8 @@ Alternatively, depend on (emacs \"24.3\") or greater, in which cl-lib is bundled
 (ert-deftest package-lint-test-error-nonstandard-symbol-separator ()
   (should
    (equal
-    '((4 1 error "`test-thing:bar' contains a non-standard separator `:', use hyphens instead.")
-      (3 1 error "`test-thing/bar' contains a non-standard separator `/', use hyphens instead."))
+    '((4 1 error "`test-thing:bar' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions).")
+      (3 1 error "`test-thing/bar' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions)."))
     (package-lint-test--run
      "(defun test-thing/bar () t)\n(defun test-thing:bar () nil)")))
   ;; But accept /= when at the end.

--- a/package-lint.el
+++ b/package-lint.el
@@ -568,7 +568,7 @@ DESC is a struct as returned by `package-buffer-info'."
           (goto-char position)
           (package-lint--error
            (line-number-at-pos) 1 'error
-           (format "`%s' contains a non-standard separator `%s', use hyphens instead."
+           (format "`%s' contains a non-standard separator `%s', use hyphens instead (see Elisp Coding Conventions)."
                    name (substring-no-properties name match-pos (1+ match-pos)))))))))
 
 (defun package-lint--check-defs-prefix (definitions)


### PR DESCRIPTION
Still seeing a lot of new recipe submissions ignoring this, which requires manually asking the author to fix it, which defeats the whole point of this check.  Maybe this will help.