### PR TITLE
Check autoloads

### DIFF
--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -44,6 +44,13 @@ used."
     (let ((buffer-file-name "test.el"))
       (package-lint-buffer))))
 
+(ert-deftest package-lint-test-check-autoloads-on-private-functions ()
+  (should
+   (equal
+    '((3 0 warning "Private functions generally should not be autoloaded."))
+    (package-lint-test--run ";;;###autoload\n(defun test-prefix--private-function ")))
+  (should (equal '() (package-lint-test--run "(defun test-prefix--private-function "))))
+
 (ert-deftest package-lint-test-warn-literal-emacs-path ()
   (should
    (equal

--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -44,6 +44,26 @@ used."
     (let ((buffer-file-name "test.el"))
       (package-lint-buffer))))
 
+(ert-deftest package-lint-test-check-for-needed-autoloads ()
+  ;; Positives
+  (should
+   (equal
+    '((2 0 warning "\"define-minor-mode\" generally should be autoloaded."))
+    (package-lint-test--run "(define-minor-mode test-something ")))
+  (should
+   (equal
+    '((2 0 warning "Interactive commands generally should be autoloaded."))
+    (package-lint-test--run "(defun test-something \n\"Docstring\"\n(interactive)\n")))
+  ;; Negatives
+  (should
+   (equal
+    nil
+    (package-lint-test--run ";;;###autoload\n(define-minor-mode test-something ")))
+  (should
+   (equal
+    nil
+    (package-lint-test--run ";;;###autoload\n(defun test-something \n\"Docstring\"\n(interactive)\n"))))
+
 (ert-deftest package-lint-test-check-autoloads-on-private-functions ()
   (should
    (equal

--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -56,13 +56,9 @@ used."
     (package-lint-test--run "(defun test-something \n\"Docstring\"\n(interactive)\n")))
   ;; Negatives
   (should
-   (equal
-    nil
-    (package-lint-test--run ";;;###autoload\n(define-minor-mode test-something ")))
+   (equal nil (package-lint-test--run ";;;###autoload\n(define-minor-mode test-something ")))
   (should
-   (equal
-    nil
-    (package-lint-test--run ";;;###autoload\n(defun test-something \n\"Docstring\"\n(interactive)\n"))))
+   (equal nil (package-lint-test--run ";;;###autoload\n(defun test-something \n\"Docstring\"\n(interactive)\n"))))
 
 (ert-deftest package-lint-test-check-autoloads-on-private-functions ()
   (should

--- a/package-lint.el
+++ b/package-lint.el
@@ -270,12 +270,15 @@ This is bound dynamically while the checks run.")
     (dolist (def defs)
       (goto-char (point-min))
       (while (re-search-forward (rx-to-string `(seq bol "(" ,def (1+ space))) nil t)
-        (save-excursion
-          (forward-line -1)
-          (unless (looking-at (rx ";;;###autoload"))
-            (package-lint--error
-             (line-number-at-pos) (current-column) 'warning
-             (format "\"%s\" generally should be autoloaded." def)))))))
+        (unless (or (nth 3 (syntax-ppss))
+                    (nth 4 (syntax-ppss)))
+          ;; Not in string or comment
+          (save-excursion
+            (forward-line -1)
+            (unless (looking-at (rx ";;;###autoload"))
+              (package-lint--error
+               (line-number-at-pos) (current-column) 'warning
+               (format "\"%s\" generally should be autoloaded." def))))))))
   ;; Check interactive functions
   (goto-char (point-min))
   (while (re-search-forward (rx "(interactive)") nil t)


### PR DESCRIPTION
This adds checks for common necessary and unnecessary autoloads, currently `define-minor-mode` and interactive commands.