### PR TITLE
Detect customization group names ending in “-mode”.

### DIFF
--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -400,5 +400,19 @@ Alternatively, depend on (emacs \"24.3\") or greater, in which cl-lib is bundled
     '((5 0 warning "Use `define-globalized-minor-mode' to define global minor modes."))
     (package-lint-test--run "(define-global-minor-mode test-mode ignore ignore :require 'test)"))))
 
+(ert-deftest package-lint-test-error-defgroup-name ()
+  (should
+   (equal
+    '((5 0 error "Customization groups should not end in \"-mode\" unless that name would conflict with their parent group."))
+    (package-lint-test--run "(defgroup test-mode nil \"\")")))
+  (should
+   (equal
+    '((5 0 error "Customization groups should not end in \"-mode\" unless that name would conflict with their parent group."))
+    (package-lint-test--run "(defgroup test-mode nil \"\" :group 'testing)")))
+  (should
+   (equal
+    '()
+    (package-lint-test--run "(defgroup test-mode nil \"\" :group 'test)"))))
+
 (provide 'package-lint-test)
 ;;; package-lint-test.el ends here

--- a/package-lint.el
+++ b/package-lint.el
@@ -252,6 +252,8 @@ This is bound dynamically while the checks run.")
           (package-lint--check-objects-by-regexp
            "(define-global\\(?:ized\\)?-minor-mode\\s-"
            #'package-lint--check-globalized-minor-mode)
+          (package-lint--check-objects-by-regexp
+           "(defgroup\\s-" #'package-lint--check-defgroup)
           (let ((desc (package-lint--check-package-el-can-parse)))
             (when desc
               (package-lint--check-package-summary desc)
@@ -696,6 +698,17 @@ DESC is a struct as returned by `package-buffer-info'."
        'error
        (format
         "Global minor modes must `:require' their defining file (i.e. \":require '%s\"), to support the customization variable of the same name." feature)))))
+
+(defun package-lint--check-defgroup (def)
+  "Offer up concerns about the customization group definition DEF."
+  (when (symbolp (cadr def))
+    (let ((group-name (symbol-name (cadr def))))
+      (when (string-match "\\(.*\\)-mode$" group-name)
+        (let ((parent (intern (match-string 1 group-name))))
+          (unless (cl-search `(:group ',parent) def :test #'equal)
+            (package-lint--error-at-point
+             'error
+             "Customization groups should not end in \"-mode\" unless that name would conflict with their parent group.")))))))
 
 
 ;;; Helpers


### PR DESCRIPTION
Such names are not idiomatic, and at odds with the default behavior of
e.g. `define-minor-mode`. They are only used when the group name
without “-mode” is already used for non-mode-specific configuration
options, in which case it should be used as the parent group.

This addresses issue #78.