### PR TITLE
Do not warn about paths like “/foo/foo.emacs.dat”.

### DIFF
--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -120,8 +120,13 @@ with the passed string, when it's nil, the default is used."
 (ert-deftest package-lint-test-warn-literal-emacs-path ()
   (should
    (equal
-    '((5 8 warning "Use variable `user-emacs-directory' or function `locate-user-emacs-file' instead of a literal path to the Emacs user directory or files."))
-    (package-lint-test--run "\.emacs\.d")))
+    '((5 9 warning "Use variable `user-emacs-directory' or function `locate-user-emacs-file' instead of a literal path to the Emacs user directory or files."))
+    (package-lint-test--run "\".emacs\.d\"")))
+  (should
+   (equal
+    '((5 11 warning "Use variable `user-emacs-directory' or function `locate-user-emacs-file' instead of a literal path to the Emacs user directory or files."))
+    (package-lint-test--run "\"~/.emacs\.d/foo\"")))
+  (should (equal '() (package-lint-test--run "\"/foo/foo.emacs.dat\"")))
   (should (equal '() (package-lint-test--run ";; ~/\.emacs\.d/elpa")))
   (should (equal '() (package-lint-test--run "\"emacs dot dee\""))))
 

--- a/package-lint.el
+++ b/package-lint.el
@@ -336,11 +336,14 @@ This is bound dynamically while the checks run.")
   "Verify package does not refer to \"\.emacs\.d\" literally.
 Instead it should use `user-emacs-directory' or `locate-user-emacs-file'."
   (goto-char (point-min))
-  (while (re-search-forward "\\.emacs\\.d" nil t)
+  ;; \b won't find a word boundary between a symbol and the "." in
+  ;; ".emacs.d". / is a valid symbol constituent in Emacs Lisp, so
+  ;; must be explicitly blacklisted.
+  (while (re-search-forward "\\(?:\\_<\\|/\\)\\.emacs\\.d\\b" nil t)
     (unless (nth 4 (syntax-ppss))
       ;; Not in a comment
-      (package-lint--error
-       (line-number-at-pos) (current-column) 'warning
+      (package-lint--error-at-point
+       'warning
        "Use variable `user-emacs-directory' or function `locate-user-emacs-file' instead of a literal path to the Emacs user directory or files."))))
 
 (defun package-lint--check-keywords-list ()


### PR DESCRIPTION
Instead, bad paths must have a symbol delimiter (e.g. a quote) or a /
before the first dot, and a word break after the “d”.

Update the existing test cases so they are valid Emacs Lisp, by
making the test path a string.

This addresses issue #67.