### PR TITLE
Add package-lint binary

### DIFF
--- a/bin/package-lint
+++ b/bin/package-lint
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+usage () {
+    cat <<EOF
+[cask exec] package-lint [FILES]
+
+Arguments:
+
+FILES:
+  Package lint will use files defined in Cask by default if no files are
+  specified as arguments.
+
+EOF
+}
+
+CASK="${CASK:=cask}"
+EMACS="${EMACS:=emacs}"
+FILES="$*"
+
+INIT_PACKAGE_EL="(progn
+  (require 'package)
+  (setq package-user-dir \"$($CASK package-directory)\")
+  (setq package-archives
+        (mapcar
+         (lambda (archive)
+           (list archive))
+         (cl-delete-if
+          (lambda (file) (string-prefix-p \".\" file))
+          (directory-files (concat package-user-dir \"/archives\")))))
+  (package-read-all-archive-contents))"
+
+if [ -z "$FILES" ]; then
+    FILES=$("$CASK" files)
+fi
+
+EMACS_ARGS=()
+while [[ "$#" -gt 0 ]]
+do
+    case "$1" in
+        "-h"|"--help")
+            usage
+            exit
+            ;;
+        "-L"|"--directory"|"-f"|"--funcall"|"-l"|"--load"|"--eval"|"--execute")
+            EMACS_ARGS+=("$1")
+            EMACS_ARGS+=("$2")
+            shift
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+
+"$EMACS" -Q -batch \
+         "${EMACS_ARGS[@]}" \
+         --eval "$INIT_PACKAGE_EL" \
+         -L . \
+         -l package-lint.el \
+         -f package-lint-batch-and-exit \
+         $FILES


### PR DESCRIPTION
For projects using cask there is the handy `cask exec` command to execute "binaries" packaged with packages.  They are stored in a `bin` directory as simple executable files.

This patch adds a `package-lint` binary so that you can simply `cask exec package-lint` and it will automatically set up the load path, archives and everything according to `Cask`.  You can also specify the files you want to check as arguments (by default uses all files returned by `cask files`).

This should fix #73 and also make builds on CIs much more pleasant.

I can imagine this to also be used in travis-ci for MELPA if we can detect that the project uses Cask.  We can later make it more configurable to be able to run without cask as well... but I would strongly push for cask adoption among "serious" packages (maybe even require it by package-lint itself as a check).