### PR TITLE
Make it possible to force acceptance of a dependency version

### DIFF
--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -304,6 +304,13 @@ it's nil, the default is used."
     (should
      (equal '() (package-lint-test--run ";; Package-Requires: ((package-lint-foobar \"0.3.0\"))")))))
 
+(ert-deftest package-lint-test-dont-warn-dependency-too-high-4 ()
+  (let ((package-lint-accepted-dependencies '((package-lint-foobar (0 6 0))))
+        (package-archive-contents nil))
+    (package-lint-test-add-package-lint-foobar-to-archive '(0 5 0))
+    (should
+     (equal '() (package-lint-test--run ";; Package-Requires: ((package-lint-foobar \"0.6.0\"))")))))
+
 (ert-deftest package-lint-test-error-cl-lib-1.0-dep ()
   (should
    (member


### PR DESCRIPTION
Add a variable `package-lint-accepted-dependencies` to list dependencies that should be accepted even if not in any package archive.

This PR also adds a test for an existing check.
