### PR TITLE
Dependency too high bug

### DIFF
--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -295,6 +295,15 @@ it's nil, the default is used."
     (should
      (equal '() (package-lint-test--run ";; Package-Requires: ((package-lint-foobar \"0.5.0\"))")))))
 
+(ert-deftest package-lint-test-dont-warn-dependency-too-high-3 ()
+  (let ((package-archive-contents nil))
+    ;; Sometimes a package appears with different versions from
+    ;; different archives:
+    (package-lint-test-add-package-lint-foobar-to-archive '(0 5 0) "gnu")
+    (package-lint-test-add-package-lint-foobar-to-archive '(0 1 0) "melpa-stable")
+    (should
+     (equal '() (package-lint-test--run ";; Package-Requires: ((package-lint-foobar \"0.3.0\"))")))))
+
 (ert-deftest package-lint-test-error-cl-lib-1.0-dep ()
   (should
    (member

--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -28,6 +28,16 @@
 (require 'package-lint)
 (require 'ert)
 
+(defun package-lint-test-add-package-lint-foobar-to-archive (version &optional archive)
+  "Add a package-lint-foobar package to melpa-stable archive.
+VERSION is a list of numbers, e.g., (0 5 0) to represent version
+0.5.0."
+  (package--add-to-archive-contents
+   `(package-lint-foobar . [,version ((emacs (25 1))) "Some documentation" single
+                                     ((:commit . "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+                                      (:url . "https://gitlab.com/somewhere"))])
+   (or archive "melpa-stable")))
+
 (defun package-lint-test--run (contents &optional header version footer provide commentary url)
   "Run `package-lint-buffer' on a temporary buffer with given CONTENTS.
 
@@ -264,6 +274,26 @@ it's nil, the default is used."
    (equal
     '((6 24 warning "Use a properly versioned dependency on \"package-lint\" if possible."))
     (package-lint-test--run ";; Package-Requires: ((package-lint \"0\"))"))))
+
+(ert-deftest package-lint-test-warn-dependency-too-high ()
+  (let ((package-archive-contents nil))
+    (package-lint-test-add-package-lint-foobar-to-archive '(0 5 0))
+    (should
+     (equal
+      '((6 24 warning "Version dependency for package-lint-foobar appears too high: try 0.5.0"))
+      (package-lint-test--run ";; Package-Requires: ((package-lint-foobar \"0.6.0\"))")))))
+
+(ert-deftest package-lint-test-dont-warn-dependency-too-high-1 ()
+  (let ((package-archive-contents nil))
+    (package-lint-test-add-package-lint-foobar-to-archive '(0 5 0))
+    (should
+     (equal '() (package-lint-test--run ";; Package-Requires: ((package-lint-foobar \"0.5.0\"))")))))
+
+(ert-deftest package-lint-test-dont-warn-dependency-too-high-2 ()
+  (let ((package-archive-contents nil))
+    (package-lint-test-add-package-lint-foobar-to-archive '(0 6 0))
+    (should
+     (equal '() (package-lint-test--run ";; Package-Requires: ((package-lint-foobar \"0.5.0\"))")))))
 
 (ert-deftest package-lint-test-error-cl-lib-1.0-dep ()
   (should

--- a/package-lint.el
+++ b/package-lint.el
@@ -445,7 +445,7 @@ Check that package described by ARCHIVE-ENTRY can be installed at
 required version PACKAGE-VERSION.  If not, raise an error for
 LINE-NO at OFFSET."
   (let* ((package-name (car archive-entry))
-         (best-version (package-lint--lowest-installable-version-of package-name)))
+         (best-version (package-lint--highest-installable-version-of package-name)))
     (when (version-list-< best-version package-version)
       (package-lint--error
        line-no offset 'warning
@@ -792,12 +792,12 @@ Lines consisting only of whitespace or empty comments are considered empty."
                     (= 0 (forward-line))))
         (eobp)))))
 
-(defun package-lint--lowest-installable-version-of (package)
-  "Return the lowest version of PACKAGE available for installation."
+(defun package-lint--highest-installable-version-of (package)
+  "Return the highest version of PACKAGE available for installation."
   (let ((descriptors (cdr (assq package package-archive-contents))))
     (if (fboundp 'package-desc-version)
         (car (sort (mapcar 'package-desc-version descriptors)
-                   #'version-list-<))
+                   (lambda (v1 v2) (not (version-list-< v1 v2)))))
       (aref descriptors 0))))
 
 (defun package-lint--goto-header (header-name)

--- a/package-lint.el
+++ b/package-lint.el
@@ -879,7 +879,7 @@ Prefix is returned without any `-mode' suffix."
 (defun package-lint--check-objects-by-regexp (regexp function)
   "Check all objects with the literal printed form matching REGEXP.
 
-The objects are parsed with `read'. The FUNCTION is passed the
+The objects are parsed with `read'.  The FUNCTION is passed the
 read object, with the point at the beginning of the match.
 
 S-expressions in comments or comments, partial s-expressions, or


### PR DESCRIPTION
This PR refactors the "dependency too high" warning code and fixes an issue where this warning would be raised in undesired situations (see #102) for more information.

@purcell I'm making this PR so you can merge it even if you don't like the new feature in #102.