### PR TITLE
add functions that require emacs 24.4

### DIFF
--- a/package-lint.el
+++ b/package-lint.el
@@ -147,6 +147,7 @@ This is bound dynamically while the checks run.")
           group-real-gid
           hash-table-keys
           hash-table-values
+          line-pixel-height
           macrop
           remove-function
           set-file-acl
@@ -164,6 +165,7 @@ This is bound dynamically while the checks run.")
           window-bottom-divider-width
           window-header-line-height
           window-mode-line-height
+          window-pixel-height
           window-right-divider-width
           window-scroll-bar-width
           window-text-pixel-size


### PR DESCRIPTION
Hopefully I've done this correctly -- I grepped through the source code for a few Emacs releases and noticed these two methods were added late in 24.3 (i.e. they were not present in 24.3, but they were present in 24.3.92).