### PR TITLE
Silence Emacs 25's byte-compiler

### DIFF
--- a/package-lint-flymake.el
+++ b/package-lint-flymake.el
@@ -1,34 +1,36 @@
 ;;; package-lint-flymake.el --- A package-lint Flymake backend  -*- lexical-binding: t; -*-
-;;
+
 ;; Copyright (C) 2018 J. Alexander Branham (alex DOT branham AT gmail DOT com)
-;;
+
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; This is free software; you can redistribute it and/or modify it under
 ;; the terms of the GNU General Public License as published by the Free
 ;; Software Foundation; either version 3, or (at your option) any later
 ;; version.
-;;
+
 ;; This is distributed in the hope that it will be useful, but WITHOUT
 ;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 ;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 ;; for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs; see the file COPYING.  If not, write to the
 ;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 ;; MA 02110-1301 USA.
-;;
+
 ;;; Commentary:
-;;
+
 ;; Flymake is the built-in Emacs package to support on-the-fly syntax
 ;; checking.  This file adds support for flymake to `package-lint'.
+
 ;; Enable it by calling `package-lint-setup-flymake' from a
 ;; file-visiting buffer.  To enable in all `emacs-lisp-mode' buffers:
 ;;
 ;; (add-hook 'emacs-lisp-mode-hook #'package-lint-setup-flymake)
-;;
+
 ;;; Code:
+
 (eval-when-compile
   (require 'cl-lib))
 (require 'flymake)

--- a/package-lint-flymake.el
+++ b/package-lint-flymake.el
@@ -22,7 +22,8 @@
 ;;; Commentary:
 
 ;; Flymake is the built-in Emacs package to support on-the-fly syntax
-;; checking.  This file adds support for flymake to `package-lint'.
+;; checking.  This library adds support for flymake to `package-lint'.
+;; It requires Emacs 26.
 
 ;; Enable it by calling `package-lint-setup-flymake' from a
 ;; file-visiting buffer.  To enable in all `emacs-lisp-mode' buffers:
@@ -37,6 +38,9 @@
 (require 'package-lint)
 
 (defvar-local package-lint--flymake-proc nil)
+
+(declare-function flymake-diag-region "flymake")
+(declare-function flymake-make-diagnostic "flymake")
 
 (defun package-lint-flymake (report-fn &rest _args)
   "A Flymake backend for `package-lint'.


### PR DESCRIPTION
`flymake-diag-region` and `flymake-make-diagnostic` were added in
Emacs 26.  `package-lint-setup-flymake` errors out if the user tries
to use the functionality provided by this library when using an older
Emacs, but that doesn't prevent warnings when compiling this library,
which happens even on incompatible Emacsen.

Declare the functions to silence the byte-compiler.  An alternative
approach would be to distribute this library as a separate package,
but that seems a bit drastic.

There's a second commit which does unrelated cleanup.

Totally unrelated, I would recommend you move this to the `melpa` organisation, where it can sit next to `package-build`. :wink: 