### PR TITLE
Accept usage of cl-defmethod

### DIFF
--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -439,6 +439,9 @@ Alternatively, depend on (emacs \"24.3\") or greater, in which cl-lib is bundled
   ;; confused by weird spacing.
   (should (equal '() (package-lint-test--run "   (  defadvice \t\n\n foo (before ignore))"))))
 
+(ert-deftest package-lint-test-accept-unprefixed-cl-defmethod ()
+  (should (equal '() (package-lint-test--run "(cl-defmethod foo ()"))))
+
 (ert-deftest package-lint-test-minor-mode-global-t ()
   (should
    (equal

--- a/package-lint.el
+++ b/package-lint.el
@@ -737,7 +737,7 @@ Valid definition names are:
       (progn
         (goto-char position)
         (looking-at-p (rx (*? space) "(" (*? space)
-                          "defadvice"
+                          (or "defadvice" "cl-defmethod")
                           symbol-end)))))
 
 (defun package-lint--check-defs-prefix (definitions)


### PR DESCRIPTION
`cl-defmethod` can extend generic definitions coming from other packages: they don't have to start with package prefix.