### PR TITLE
Allow define-/defun-/list- before package prefix

### DIFF
--- a/package-lint.el
+++ b/package-lint.el
@@ -770,7 +770,8 @@ Valid definition names are:
       (let ((prefix-re
              (rx-to-string
               `(seq string-start
-                    (or (seq ,prefix (or "-" string-end))
+                    (or (seq (opt (or "define-" "defun-" "list-"))
+                             ,prefix (or "-" string-end))
                         (seq "global-"
                              ,prefix
                              (or "-mode"

--- a/package-lint.el
+++ b/package-lint.el
@@ -770,7 +770,7 @@ Valid definition names are:
       (let ((prefix-re
              (rx-to-string
               `(seq string-start
-                    (or (seq (opt (or "define-" "defun-" "list-"))
+                    (or (seq (opt (or "define-" "defun-" "defvar-"))
                              ,prefix (or "-" string-end))
                         (seq "global-"
                              ,prefix


### PR DESCRIPTION
The Emacs Lisp Coding Conventions section in the GNU Emacs Lisp
Reference Manual says: "Occasionally, for a command name intended for
users to use, it is more convenient if some words come before the
package's name prefix. For example, it is our convention to have
commands that list objects named as ‘list-something’, e.g., a package
called ‘frob’ could have a command ‘list-frobs’, when its other global
symbols begin with ‘frob-’. Also, constructs that define functions,
variables, etc., work better if they start with ‘defun’ or ‘defvar’,
so put the name prefix later on in the name."