### PR TITLE
Check globalized-minor-mode only when package can be parsed

### DIFF
--- a/package-lint.el
+++ b/package-lint.el
@@ -270,12 +270,12 @@ This is bound dynamically while the checks run.")
            "(define-minor-mode\\s-"
            #'package-lint--check-minor-mode)
           (package-lint--check-objects-by-regexp
-           "(define-global\\(?:ized\\)?-minor-mode\\s-"
-           #'package-lint--check-globalized-minor-mode)
-          (package-lint--check-objects-by-regexp
            "(defgroup\\s-" #'package-lint--check-defgroup)
           (let ((desc (package-lint--check-package-el-can-parse)))
             (when desc
+              (package-lint--check-objects-by-regexp
+               "(define-global\\(?:ized\\)?-minor-mode\\s-"
+               #'package-lint--check-globalized-minor-mode)
               (package-lint--check-package-summary desc)
               (package-lint--check-provide-form desc)))
           (package-lint--check-no-use-of-cl)

--- a/package-lint.el
+++ b/package-lint.el
@@ -270,15 +270,15 @@ This is bound dynamically while the checks run.")
            "(define-minor-mode\\s-"
            #'package-lint--check-minor-mode)
           (package-lint--check-objects-by-regexp
+           "(define-global\\(?:ized\\)?-minor-mode\\s-"
+           #'package-lint--check-globalized-minor-mode)
+          (package-lint--check-objects-by-regexp
            (concat "(" (regexp-opt '("defalias" "defvaralias")) "\\s-")
            #'package-lint--check-defalias)
           (package-lint--check-objects-by-regexp
            "(defgroup\\s-" #'package-lint--check-defgroup)
           (let ((desc (package-lint--check-package-el-can-parse)))
             (when desc
-              (package-lint--check-objects-by-regexp
-               "(define-global\\(?:ized\\)?-minor-mode\\s-"
-               #'package-lint--check-globalized-minor-mode)
               (package-lint--check-package-summary desc)
               (package-lint--check-provide-form desc)))
           (package-lint--check-no-use-of-cl)
@@ -787,17 +787,19 @@ Valid definition names are:
 
 (defun package-lint--check-globalized-minor-mode (def)
   "Offer up concerns about the global minor mode definition DEF."
-  (let ((feature (intern (package-lint--provided-feature)))
-        (autoloaded (save-excursion
-                      (forward-line -1)
-                      (beginning-of-line)
-                      (looking-at ";;;###autoload"))))
-    (unless (or autoloaded
-                (cl-search `(:require ',feature) def :test #'equal))
-      (package-lint--error-at-point
-       'error
-       (format
-        "Global minor modes should be autoloaded or, rarely, `:require' their defining file (i.e. \":require '%s\"), to support the customization variable of the same name." feature)))))
+  (let ((feature-name (package-lint--provided-feature)))
+    (when feature-name
+      (let ((feature (intern feature-name))
+            (autoloaded (save-excursion
+                          (forward-line -1)
+                          (beginning-of-line)
+                          (looking-at ";;;###autoload"))))
+        (unless (or autoloaded
+                    (cl-search `(:require ',feature) def :test #'equal))
+          (package-lint--error-at-point
+           'error
+           (format
+            "Global minor modes should be autoloaded or, rarely, `:require' their defining file (i.e. \":require '%s\"), to support the customization variable of the same name." feature)))))))
 
 (defun package-lint--check-defgroup (def)
   "Offer up concerns about the customization group definition DEF."
@@ -818,12 +820,13 @@ Valid definition names are:
 (defun package-lint--check-defalias (def)
   "Offer up concerns about the customization group definition DEF."
   (let ((prefix (package-lint--get-package-prefix)))
-    (pcase (cadr def)
-      (`(quote ,alias)
-       (unless (package-lint--valid-definition-name-p (symbol-name alias) prefix)
-         (package-lint--error-at-point
-          'error
-          (concat "Aliases should start with the package's prefix \"" prefix "\".")))))))
+    (when prefix
+      (pcase (cadr def)
+        (`(quote ,alias)
+         (unless (package-lint--valid-definition-name-p (symbol-name alias) prefix)
+           (package-lint--error-at-point
+            'error
+            (concat "Aliases should start with the package's prefix \"" prefix "\"."))))))))
 
 
 ;;; Helpers


### PR DESCRIPTION
(for #124)

`package-lint--check-globalized-minor-mode` binds a variable to
```elisp
(intern (package-lint--provided-feature))
```
but if the package lacks a footer this will be nil, which ultimately causes an error when the rest of the check runs.

I think this fix fits, but I'll raise an issue as well in case there's more to it than I'm seeing.

