### PR TITLE
Note if-let*, when-let* added in Emacs 26.0

### DIFF
--- a/package-lint.el
+++ b/package-lint.el
@@ -234,7 +234,9 @@ This is bound dynamically while the checks run.")
           apropos-local-variable
           apropos-local-value
           dired-mouse-find-file
-          dired-mouse-find-file-other-frame))
+          dired-mouse-find-file-other-frame
+          if-let*
+          when-let*))
    (cons '(26 2)
          (package-lint--match-symbols
           read-answer


### PR DESCRIPTION
These two macros were added in https://github.com/emacs-mirror/emacs/commit/be10c00d3d64d53a7f31441d42f6c5b1f75b9916, part of Emacs 26.0.