### PR TITLE
Output compiler-style errors and warnings in batch mode

### DIFF
--- a/package-lint.el
+++ b/package-lint.el
@@ -1036,18 +1036,23 @@ Current buffer is used if none is specified."
 The main loop is this separate function so it's easier to test."
   ;; Make sure package.el is initialized so we can query its database.
   (package-initialize)
-  (let ((success t))
+  (let ((success t) (last-directory nil) (text-quoting-style 'grave))
     (dolist (file filenames success)
-      (let ((file (expand-file-name file)))
+      (let* ((file (expand-file-name file))
+             (file-directory (file-name-directory file))
+             (base (file-name-nondirectory file)))
         (with-temp-buffer
           (insert-file-contents file t)
           (emacs-lisp-mode)
           (let ((checking-result (package-lint-buffer)))
             (when checking-result
               (setq success nil)
-              (message "In `%s':" file)
+              (unless (equal last-directory file-directory)
+                (setq last-directory file-directory)
+                (message "Entering directory '%s'" file-directory))
               (pcase-dolist (`(,line ,col ,type ,message) checking-result)
-                (message "  at %d:%d: %s: %s" line col type message)))))))))
+                (message "%s:%d:%d: %s: %s"
+                         base line col type message)))))))))
 
 ;;;###autoload
 (defun package-lint-batch-and-exit ()

--- a/package-lint.el
+++ b/package-lint.el
@@ -1038,15 +1038,16 @@ The main loop is this separate function so it's easier to test."
   (package-initialize)
   (let ((success t))
     (dolist (file filenames success)
-      (with-temp-buffer
-        (insert-file-contents file t)
-        (emacs-lisp-mode)
-        (let ((checking-result (package-lint-buffer)))
-          (when checking-result
-            (setq success nil)
-            (message "In `%s':" file)
-            (pcase-dolist (`(,line ,col ,type ,message) checking-result)
-              (message "  at %d:%d: %s: %s" line col type message))))))))
+      (let ((file (expand-file-name file)))
+        (with-temp-buffer
+          (insert-file-contents file t)
+          (emacs-lisp-mode)
+          (let ((checking-result (package-lint-buffer)))
+            (when checking-result
+              (setq success nil)
+              (message "In `%s':" file)
+              (pcase-dolist (`(,line ,col ,type ,message) checking-result)
+                (message "  at %d:%d: %s: %s" line col type message)))))))))
 
 ;;;###autoload
 (defun package-lint-batch-and-exit ()

--- a/package-lint.el
+++ b/package-lint.el
@@ -1030,6 +1030,24 @@ Current buffer is used if none is specified."
       (view-mode 1))
     (display-buffer buf)))
 
+(defun package-lint-batch-and-exit-1 (filenames)
+  "Internal helper function for `package-lint-batch-and-exit'.
+
+The main loop is this separate function so it's easier to test."
+  ;; Make sure package.el is initialized so we can query its database.
+  (package-initialize)
+  (let ((success t))
+    (dolist (file filenames success)
+      (with-temp-buffer
+        (insert-file-contents file t)
+        (emacs-lisp-mode)
+        (let ((checking-result (package-lint-buffer)))
+          (when checking-result
+            (setq success nil)
+            (message "In `%s':" file)
+            (pcase-dolist (`(,line ,col ,type ,message) checking-result)
+              (message "  at %d:%d: %s: %s" line col type message))))))))
+
 ;;;###autoload
 (defun package-lint-batch-and-exit ()
   "Run `package-lint-buffer' on the files remaining on the command line.
@@ -1039,19 +1057,7 @@ When done, exit Emacs with status 0 if there were no errors nor warnings or 1
 otherwise."
   (unless noninteractive
     (error "`package-lint-batch-and-exit' is to be used only with -batch"))
-  ;; Make sure package.el is initialized so we can query its database.
-  (package-initialize)
-  (let ((success t))
-    (dolist (file command-line-args-left)
-      (with-temp-buffer
-        (insert-file-contents file t)
-        (emacs-lisp-mode)
-        (let ((checking-result (package-lint-buffer)))
-          (when checking-result
-            (setq success nil)
-            (message "In `%s':" file)
-            (pcase-dolist (`(,line ,col ,type ,message) checking-result)
-              (message "  at %d:%d: %s: %s" line col type message))))))
+  (let ((success (package-lint-batch-and-exit-1 command-line-args-left)))
     (kill-emacs (if success 0 1))))
 
 ;;;###autoload


### PR DESCRIPTION
The output now reads like many compilers' output:

```
Entering directory '/absolute/path/to/directory'
filename:line:column: error|warning: message
filename:line:column: error|warning: message
...
```

That means Emacs' compilation-mode can make hyperlinks from the errors and lets you easily jump to the location of each error.