### PR TITLE
Enforce datetime versions for melpa packages

### DIFF
--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -272,14 +272,24 @@ headers and provide form."
 (ert-deftest package-lint-test-warn-snapshot-dep ()
   (should
    (equal
-    '((6 24 warning "Use a non-snapshot version number for dependency on \"package-lint\" if possible."))
-    (package-lint-test--run ";; Package-Requires: ((package-lint \"20160101.1234\"))"))))
+    '((6 24 warning "Use a snapshot version for melpa package \"package-lint\"."))
+    (package-lint-test--run ";; Package-Requires: ((package-lint \"0.2\"))"))))
+
+(ert-deftest package-lint-test-warn-non-snapshot-dep ()
+  (should
+   (member
+    '(6 24 warning "Use a non-snapshot version for non-melpa package \"org\".")
+    (package-lint-test--run ";; Package-Requires: ((org \"20190707\"))"))))
+
+(ert-deftest package-lint-test-dual-listing-dep ()
+  (should (equal '() (package-lint-test--run ";; Package-Requires: ((which-key \"20190707\"))")))
+  (should (equal '() (package-lint-test--run ";; Package-Requires: ((which-key \"3.3.0\"))"))))
 
 (ert-deftest package-lint-test-warn-unversioned-dep ()
   (should
    (equal
-    '((6 24 warning "Use a properly versioned dependency on \"package-lint\" if possible."))
-    (package-lint-test--run ";; Package-Requires: ((package-lint \"0\"))"))))
+    '((6 24 warning "Use a properly versioned dependency on \"rainbow-mode\" if possible."))
+    (package-lint-test--run ";; Package-Requires: ((rainbow-mode \"0\"))"))))
 
 (ert-deftest package-lint-test-warn-dependency-too-high ()
   (let ((package-archive-contents nil))
@@ -319,7 +329,7 @@ Alternatively, depend on (emacs \"24.3\") or greater, in which cl-lib is bundled
 
 (ert-deftest package-lint-test-accept-normal-deps ()
   (should (equal '() (package-lint-test--run
-                      ";; Package-Requires: ((package-lint \"0.2\") (cl-lib \"0.5\"))"))))
+                      ";; Package-Requires: ((package-lint \"20190707\") (cl-lib \"0.5\"))"))))
 
 (ert-deftest package-lint-test-error-new-functions ()
   (should

--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -270,16 +270,18 @@ headers and provide form."
     (package-lint-test--run ";; Package-Requires: ((example-nonexistent-package \"1\"))"))))
 
 (ert-deftest package-lint-test-warn-snapshot-dep ()
-  (should
-   (equal
-    '((6 24 warning "Use a snapshot version for melpa package \"package-lint\"."))
-    (package-lint-test--run ";; Package-Requires: ((package-lint \"0.2\"))"))))
+  (when (version-list-<= (version-to-list "24.4") (version-to-list emacs-version))
+    (should
+     (equal
+      '((6 24 warning "Use a snapshot version for melpa package \"package-lint\"."))
+      (package-lint-test--run ";; Package-Requires: ((package-lint \"0.2\"))")))))
 
 (ert-deftest package-lint-test-warn-non-snapshot-dep ()
-  (should
-   (member
-    '(6 24 warning "Use a non-snapshot version for non-melpa package \"org\".")
-    (package-lint-test--run ";; Package-Requires: ((org \"20190707\"))"))))
+  (when (version-list-<= (version-to-list "24.4") (version-to-list emacs-version))
+    (should
+     (member
+      '(6 24 warning "Use a non-snapshot version for non-melpa package \"org\".")
+      (package-lint-test--run ";; Package-Requires: ((org \"20190707\"))")))))
 
 (ert-deftest package-lint-test-dual-listing-dep ()
   (should (equal '() (package-lint-test--run ";; Package-Requires: ((which-key \"20190707\"))")))

--- a/package-lint.el
+++ b/package-lint.el
@@ -390,12 +390,12 @@ LINE-NO at OFFSET."
 (defun package-lint--check-deps-use-proper-version (valid-deps)
   "Warn about any VALID-DEPS on snapshot versions of packages."
   (pcase-dolist (`(,package-name ,package-version ,line-no ,offset) valid-deps)
-    (let* ((archive (when-let ((archive-entry
-                                (car (alist-get package-name package-archive-contents))))
-                      (package-desc-archive archive-entry)))
-           (melpa-p (string= archive "melpa"))
+    (let* ((archive-entries (cdr (assq package-name package-archive-contents)))
+           (dual-p (> (length archive-entries) 1))
+           (melpa-p (and (= (length archive-entries) 1)
+                         (string= (package-desc-archive (car archive-entries)) "melpa")))
            (snapshot-p (package-lint--snapshot-p package-version)))
-      (when (not (eq melpa-p snapshot-p))
+      (when (and (not dual-p) (not (eq melpa-p snapshot-p)))
         (package-lint--error
          line-no offset 'warning
          (format "Use a %ssnapshot version for %smelpa package \"%S\"."

--- a/package-lint.el
+++ b/package-lint.el
@@ -393,6 +393,7 @@ LINE-NO at OFFSET."
     (let* ((archive-entries (cdr (assq package-name package-archive-contents)))
            (dual-p (> (length archive-entries) 1))
            (melpa-p (and (= (length archive-entries) 1)
+                         (fboundp 'package-desc-archive)
                          (string= (package-desc-archive (car archive-entries)) "melpa")))
            (snapshot-p (package-lint--snapshot-p package-version)))
       (when (and (not dual-p) (not (eq melpa-p snapshot-p)))


### PR DESCRIPTION
We can't and probably shouldn't change `package.el` to bend to melpa's datetime versioning.  I recommend going all-in on that versioning.

cf. melpa/melpa#2955

Closes #99 