### PR TITLE
Extension point for package manager ( fix #108 )

### DIFF
--- a/package-lint.el
+++ b/package-lint.el
@@ -1,4 +1,3 @@
-;;; WIP: extension point for different package handler (namely straight.el)
 ;;; package-lint.el --- A linting library for elisp package authors -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2014-2019  Steve Purcell, Fanael Linithien

--- a/package-lint.el
+++ b/package-lint.el
@@ -1,3 +1,4 @@
+;;; WIP: extension point for different package handler (namely straight.el)
 ;;; package-lint.el --- A linting library for elisp package authors -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2014-2019  Steve Purcell, Fanael Linithien


### PR DESCRIPTION
Provide an API so other devs/package maintainers can extend the checking packages to their needs. The overall goal is to support `straight.el`, an alternative package manager.

Instructions of use:
- Put a function that evaluates the context and returns a tag identifying what manager is being used
- Extend `package-lint--checkpackages-installable` for that package manager tag.

Example:

    (defun my/package-lint-straight-package-manager ()
      'straight)
    (setq-default package-lint-package-manager-function
		#'my/package-lint-straight-package-manager)

    (require 'cl-generic)
    (cl-defmethod package-lint--check-packages-installable ((_package-manager
							    (eql 'straight))
							    valid-deps)
    (pcase-dolist (`(,package-name ,_package-version ,dep-pos) valid-deps)
	(if-let* ((recipe (gethash (symbol-name package-name)
				straight--recipe-cache)))
	    (package-lint--error-at-point ;; let off with a warning
	      'warning
	      (format
	      (s-join " "
		    "Dependency"
		    (format "'%s" package-name)
		    "is not listed in package archive "
		    "(installed with straight.el)"))
	      dep-pos)
	(package-lint--error-at-point
	  'error
	  (format "Package %S has no recipe." package-name)
	  dep-pos))))

I dunno what/where/if to add documentation for this feature. Perhaps this sample code is enough?