### PR TITLE
Warn when package summary end with period

### DIFF
--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -233,6 +233,14 @@ headers and provide form."
      ""
      ";;; test.el --- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n"))))
 
+(ert-deftest package-lint-test-warn-summary-end-with-period ()
+  (should
+   (equal
+    '((1 0 warning "The package summary should not end with a period."))
+    (package-lint-test--run
+     ""
+     ";;; test.el --- A test.\n"))))
+
 (ert-deftest package-lint-test-warn-emacs-in-summary ()
   (should
    (equal

--- a/package-lint.el
+++ b/package-lint.el
@@ -681,6 +681,10 @@ DESC is a struct as returned by `package-buffer-info'."
         (package-lint--error-at-bob
          'warning
          "The package summary is too long. It should be at most 60 characters."))
+      (when (string-match "\\.\\'" summary)
+        (package-lint--error-at-bob
+         'warning
+         "The package summary should not end with a period."))
       (when (save-match-data
               (let ((case-fold-search t))
                 (and (string-match "[^.]\\<emacs\\>" summary)


### PR DESCRIPTION
Hi!

Proposal that summary should not end with period.
Currently, almost packages' summary doesn't end with period but some packages not.