### PR TITLE
Do package-refresh-contents if only missing package

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,7 +11,7 @@ INIT_PACKAGE_EL="(progn
 # package-lint and cl-lib.
 "$EMACS" -Q -batch \
          --eval "$INIT_PACKAGE_EL" \
-         --eval '(package-refresh-contents)' \
+         --eval "(unless package-archive-contents (package-refresh-contents))" \
          --eval "(unless (package-installed-p 'cl-lib) (package-install 'cl-lib))" \
          --eval "(unless (package-installed-p 'let-alist) (package-install 'let-alist))"
 


### PR DESCRIPTION
Hi!
I small fix run-tests.sh to do `package-refresh-contents` if only missing archive.
This improvement makes run-tests.sh faster when rerun.