### PR TITLE
Run CI when recieve pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  pull_request:
   push:
     paths-ignore:
     - '**.md'


### PR DESCRIPTION
I noticed GitHub Actions is not triggered via #157.
Maybe `pull_request` specification is needed.