### PR TITLE
Use local elpa directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.elc
 /.symbol-dumps
+/elpa

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -3,6 +3,7 @@
 EMACS="${EMACS:=emacs}"
 
 INIT_PACKAGE_EL="(progn
+  (setq user-emacs-directory \"`pwd`\")
   (require 'package)
   (push '(\"melpa\" . \"https://melpa.org/packages/\") package-archives)
   (package-initialize))"


### PR DESCRIPTION
Hi!
I found this package `run-tests.el` may change global user `.emacs.d` directory.
As this improvement, the Emacs via `run-tests.el` use local `elpa` directory separated from user global `.emacs.d`.