### PR TITLE
Remove the "summary should start with an uppercase letter" check

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Roadmap
 
 Additional checks for future versions:
 
-- WARN: header line formatting / capitalisation
+- WARN: header line formatting
 - trailing line presence / formatting
 - WARN: library is called *-mode but doesn't provide a major mode
 - checkdoc failures for interactive functions / defcustoms

--- a/package-lint.el
+++ b/package-lint.el
@@ -672,11 +672,6 @@ DESC is a struct as returned by `package-buffer-info'."
        'warning
        "Package should have a non-empty summary."))
      (t
-      (unless (let ((case-fold-search nil))
-                (string-match-p "^[A-Z0-9]" summary))
-        (package-lint--error-at-bob
-         'warning
-         "The package summary should start with an uppercase letter or a digit."))
       (when (> (length summary) 60)
         (package-lint--error-at-bob
          'warning


### PR DESCRIPTION
Such a requirement isn't documented in (info "(elisp)Coding Conventions")
or (info "(elisp)Library Headers"), checkdoc doesn't require it, many
libraries out there (including Emacs core and MELPA ones) don't follow
it, and often it just doesn't make sense, e.g. when the first word is
a command name, cf.

  https://github.com/melpa/melpa/pull/6354#issuecomment-520126497