### PR TITLE
Allow control over whether warnings cause batch checking to fail

### DIFF
--- a/package-lint.el
+++ b/package-lint.el
@@ -1039,6 +1039,15 @@ Current buffer is used if none is specified."
       (view-mode 1))
     (display-buffer buf)))
 
+(defgroup package-lint nil
+  "A linting library for elisp package authors"
+  :group 'development)
+
+(defcustom package-lint-batch-fail-on-warnings t
+  "When non-nil, make warnings fatal for `package-lint-batch-and-exit'."
+  :group 'package-lint
+  :type 'boolean)
+
 (defun package-lint-batch-and-exit-1 (filenames)
   "Internal helper function for `package-lint-batch-and-exit'.
 
@@ -1055,8 +1064,9 @@ The main loop is this separate function so it's easier to test."
         (with-temp-buffer
           (insert-file-contents file t)
           (emacs-lisp-mode)
-          (let ((checking-result (package-lint-buffer)))
-            (when (cl-some (lambda (err) (eq 'error (nth 2 err))) checking-result)
+          (let ((checking-result (package-lint-buffer))
+                (fail-on (cons 'error (when package-lint-batch-fail-on-warnings '(warning)))))
+            (when (cl-some (lambda (err) (memq (nth 2 err) fail-on)) checking-result)
               (setq success nil)
               (unless (equal last-directory file-directory)
                 (setq last-directory file-directory)
@@ -1071,8 +1081,8 @@ The main loop is this separate function so it's easier to test."
 Use this only with -batch, it won't work interactively.
 
 When done, exit Emacs with status 1 in case of any errors, otherwise exit
-with status 0.  If there were warnings but no errors, the exit code is
-still 0."
+with status 0.  The variable `package-lint-batch-fail-on-warnings' controls
+whether or not warnings alone produce a non-zero exit code."
   (unless noninteractive
     (error "`package-lint-batch-and-exit' is to be used only with -batch"))
   (let ((success (package-lint-batch-and-exit-1 command-line-args-left)))

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -56,12 +56,23 @@ echo "Assert clean package passes batch linting"
          -l package-lint.el \
          -f package-lint-batch-and-exit \
          batch-tests/is-clean.el
-echo "Assert package with warnings passes batch linting"
+"$EMACS" -Q -batch \
+echo "Assert package with demoted warnings passes batch linting"
 "$EMACS" -Q -batch \
          --eval "$INIT_PACKAGE_EL" \
+         --eval "(setq package-lint-batch-fail-on-warnings nil)" \
          -l package-lint.el \
          -f package-lint-batch-and-exit \
          batch-tests/just-warnings.el
+echo "Assert package with warnings fails batch linting"
+if "$EMACS" -Q -batch \
+         --eval "$INIT_PACKAGE_EL" \
+         -l package-lint.el \
+         -f package-lint-batch-and-exit \
+         batch-tests/just-warnings.el; then
+    echo "Didn't report failure when batch-linting file with errors"
+    exit 1
+fi
 echo "Assert package with errors fails batch linting"
 if "$EMACS" -Q -batch \
          --eval "$INIT_PACKAGE_EL" \


### PR DESCRIPTION
See #163, cc @stepnem.