### PR TITLE
Fix package-lint's warnings about itself

### DIFF
--- a/package-lint.el
+++ b/package-lint.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/purcell/package-lint
 ;; Keywords: lisp
 ;; Version: 0
-;; Package-Requires: ((cl-lib "0.5") (emacs "24.1") (let-alist "1.0.6"))
+;; Package-Requires: ((emacs "24.4") (let-alist "1.0.6"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
196:65: error: You should depend on (emacs "24.4") if you need
`package-desc-from-define'.

10:72: warning: An explicit dependency on cl-lib <= 1.0 is not needed
on Emacs >= 24.3.