### PR TITLE
Suggest Emacs-24.1 instead of Emacs-24 when enable lexical-binding

### DIFF
--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -205,7 +205,7 @@ headers and provide form."
 (ert-deftest package-lint-test-warn-lexical-binding-without-emacs-24-dep ()
   (should
    (equal
-    '((1 27 warning "You should depend on (emacs \"24\") if you need lexical-binding."))
+    '((1 27 warning "You should depend on (emacs \"24.1\") if you need lexical-binding."))
     (package-lint-test--run
      ""
      ";;; test.el --- A test -*- lexical-binding: t -*-\n"))))

--- a/package-lint.el
+++ b/package-lint.el
@@ -490,13 +490,13 @@ required version PACKAGE-VERSION.  If not, raise an error for DEP-POS."
        dep-pos))))
 
 (defun package-lint--check-lexical-binding-requires-emacs-24 (valid-deps)
-  "Warn about use of `lexical-binding' when Emacs 24 is not among VALID-DEPS."
+  "Warn about use of `lexical-binding' when Emacs 24.1 is not among VALID-DEPS."
   (goto-char (point-min))
   (when (package-lint--lexical-binding-declared-in-header-line-p)
     (unless (assq 'emacs valid-deps)
       (package-lint--error-at-point
        'warning
-       "You should depend on (emacs \"24\") if you need lexical-binding."
+       "You should depend on (emacs \"24.1\") if you need lexical-binding."
        (match-beginning 1)))))
 
 (defun package-lint--inside-comment-or-string-p ()


### PR DESCRIPTION
Suggest Emacs-24.1 instead of Emacs-24 when enable lexical-binding.

Most warnings are recommended in version format with one decimal
place.  In fact, it was introduced somewhere in the development
version of 24.0.x, so specifying 24.1 is more reasonable than
specifying 24.