### PR TITLE
Add package-lint-check-symbol feature

### DIFF
--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -750,5 +750,26 @@ Alternatively, depend on (emacs \"24.3\") or greater, in which cl-lib is bundled
     '((6 0 error "\"org-foobaz-test\" doesn't start with package's prefix \"ox-foobar\"."))
     (package-lint-test--run "(defun org-foobaz-test ()) (provide 'ox-foobar)" nil nil nil "ox-foobar" nil nil "ox-foobar"))))
 
+(ert-deftest package-lint-test-check-symbol ()
+  (should
+   (equal
+    '((features added (24 3)))
+    (package-lint-check-symbol 'cl-lib)))
+  (should
+   (equal
+    '((features added (24 4)))
+    (package-lint-check-symbol 'subr-x)))
+  (should
+   (equal
+    '((features added (24 4)))
+    (package-lint-check-symbol 'subr-x)))
+  (should
+   (equal
+    '((functions added (24 1))
+      (functions removed (26 1))
+      (variables added (24 1))
+      (variables removed (26 1)))
+    (package-lint-check-symbol 'gnus-sync-unload-hook))))
+
 (provide 'package-lint-test)
 ;;; package-lint-test.el ends here

--- a/package-lint.el
+++ b/package-lint.el
@@ -148,7 +148,7 @@ published in ELPA for use by older Emacsen.")
 
     (defconst package-lint--check-symbol-hash-table
       (let ((tbl (make-hash-table))
-            (tbl* (make-hash-table)))
+            (tbl-sorted (make-hash-table)))
         (pcase-dolist (`(,ver . ,info) stdlib-changes)
           (pcase-dolist (`(,kind (removed . ,removed) (added . ,added)) info)
             (dolist (r removed)
@@ -159,9 +159,9 @@ published in ELPA for use by older Emacsen.")
                    (let ((res (sort (nreverse value)
                                     (lambda (a b)
                                       (string< (symbol-name (car a)) (symbol-name (car b)))))))
-                     (puthash key res tbl*)))
+                     (puthash key res tbl-sorted)))
                  tbl)
-        tbl*)
+        tbl-sorted)
       "A hash-table contains symbol and added/removed info.")
 
     (defconst package-lint--check-symbol-hash-table-keys

--- a/package-lint.el
+++ b/package-lint.el
@@ -1182,7 +1182,7 @@ VER is list represents version."
   (mapconcat
    (lambda (elm)
      (pcase-let ((`(,kind ,status ,ver) elm))
-       (format "%s(%s) is %s at Emacs-%s"
+       (format "%s(%s) was %s in Emacs %s"
                symbol kind status
                (mapconcat #'number-to-string ver "."))))
    info

--- a/package-lint.el
+++ b/package-lint.el
@@ -1159,7 +1159,7 @@ otherwise invalid read forms are ignored."
 see `hash-table-keys' was included in Emacs 24.4."
   (cl-loop for k being the hash-keys of hash-table collect k))
 
-(defun package-lint--check-symbol-create-table ()
+(defun package-lint--check-symbol-get-table ()
   "Return `package-lint--check-symbol-hash-table'."
   (if package-lint--check-symbol-hash-table
       package-lint--check-symbol-hash-table
@@ -1204,9 +1204,9 @@ VER is list represents version."
   (interactive
    (list (completing-read "Symbol: "
                           (package-lint--hash-table-keys
-                           (package-lint--check-symbol-create-table)))))
+                           (package-lint--check-symbol-get-table)))))
   (let* ((sym-symbol (if (stringp symbol) (intern symbol) symbol))
-         (info (gethash sym-symbol (package-lint--check-symbol-create-table)))
+         (info (gethash sym-symbol (package-lint--check-symbol-get-table)))
          (msg (package-lint--check-symbol-make-message sym-symbol info)))
     (if (called-interactively-p 'interactive)
         (message msg)

--- a/package-lint.el
+++ b/package-lint.el
@@ -165,10 +165,7 @@ published in ELPA for use by older Emacsen.")
       "A hash-table contains symbol and added/removed info.")
 
     (defconst package-lint--check-symbol-hash-table-keys
-      (let (keys)
-        (maphash (lambda (key _value) (push key keys))
-                 package-lint--check-symbol-hash-table)
-        (delete-dups keys))
+      (cl-loop for k being the hash-keys of package-lint--check-symbol-hash-table collect k)
       "A key list of `package-lint--check-symbol-hash-table'.")
 
     (defun package-lint--added-or-removed-function-p (sym)

--- a/package-lint.el
+++ b/package-lint.el
@@ -1181,7 +1181,7 @@ see `hash-table-keys' was included in Emacs 24.4."
             tbl-sorted))))
 
 (defun package-lint--check-symbol-make-message (symbol info)
-  "Create message from INFO.
+  "Create message from INFO for SYMBOL.
 INFO is added/removed info list of (KIND STATUS VER).
 KIND is one of (functions variables features) as symbol.
 STATUS is one of (added removed) as symbol.

--- a/package-lint.el
+++ b/package-lint.el
@@ -1193,9 +1193,9 @@ VER is list represents version."
   "Return SYMBOL is added/removed on what Emacs Version using package-lint database."
   (interactive
    (list (completing-read "Symbol: " package-lint--check-symbol-hash-table-keys)))
-  (let* ((symbol* (if (stringp symbol) (intern symbol) symbol))
-         (info (gethash symbol* package-lint--check-symbol-hash-table))
-         (msg (package-lint--check-symbol-make-message symbol info)))
+  (let* ((sym-symbol (if (stringp symbol) (intern symbol) symbol))
+         (info (gethash sym-symbol package-lint--check-symbol-hash-table))
+         (msg (package-lint--check-symbol-make-message sym-symbol info)))
     (if (called-interactively-p 'interactive)
         (message msg)
       info)))


### PR DESCRIPTION
Add `package-lint-check-symbol` feature.
This feature suggested at #181.

To use this feature, `M-x package-lint-check-symbol cl-lib`,
then you get `cl-lib(features) is added at Emacs-24.3` in echo area.

If you use =package-lint-check-symbol= in lisp program like
`(package-lint-check-symbol 'cl-lib)`, it should return `'((features added (24 3)))`.