### PR TITLE
Tidy up code for handling symbols added/removed in various Emacs versions

### DIFF
--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -504,11 +504,13 @@ Alternatively, depend on (emacs \"24.3\") or greater, in which cl-lib is bundled
     (package-lint-test--run "(spell-buffer)"))))
 
 (ert-deftest package-lint-test-allow-removed-and-readded-functions ()
+  ;; History of mm-url-encode-multipart-form-data:
+  ;; * function-added in Emacs (25 1)
+  ;; * function-removed in Emacs (24 3)
+  ;; * function-added in Emacs (24 1)
   (should
    (equal
-    ;; This is clunky, but won't currently fix
-    '((6 1 error "You should depend on (emacs \"24.1\") if you need `mm-url-encode-multipart-form-data'.")
-      (6 1 error "You should depend on (emacs \"25.1\") if you need `mm-url-encode-multipart-form-data'.")
+    '((6 1 error "You should depend on (emacs \"25.1\") if you need `mm-url-encode-multipart-form-data'.")
       (6 1 error "`mm-url-encode-multipart-form-data' was removed in Emacs version 24.3."))
     (package-lint-test--run "(mm-url-encode-multipart-form-data)")))
   (equal


### PR DESCRIPTION
Alternate formulation of #182. Replaces Also adds an interactive command, `package-lint-describe-symbol-history`, which fixes #181.