### PR TITLE
Check alias symbol from define-obsolete-{function, variable}-alias

### DIFF
--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -674,6 +674,14 @@ Alternatively, depend on (emacs \"24.3\") or greater, in which cl-lib is bundled
     (package-lint-test--run "(defvaralias 'foobar 'string-equal)")))
   (should
    (equal
+    '((6 0 error "Aliases should start with the package's prefix \"test\"."))
+    (package-lint-test--run "(define-obsolete-function-alias 'foobar 'string-equal)")))
+  (should
+   (equal
+    '((6 0 error "Aliases should start with the package's prefix \"test\"."))
+    (package-lint-test--run "(define-obsolete-variable-alias 'foobar 'string-equal)")))
+  (should
+   (equal
     '()
     (package-lint-test--run "(defalias 'test-foobar 'string-equal)")))
   (should

--- a/package-lint.el
+++ b/package-lint.el
@@ -238,7 +238,10 @@ symbol such as 'variable-added.")
             (package-lint--check-reserved-keybindings)
             (when prefix
               (package-lint--check-objects-by-regexp
-               (concat "(" (regexp-opt '("defalias" "defvaralias")) "\\s-")
+               (concat "(" (regexp-opt '("defalias" "defvaralias"
+                                         "define-obsolete-function-alias"
+                                         "define-obsolete-variable-alias"))
+                       "\\s-")
                (apply-partially #'package-lint--check-defalias prefix)))
             (package-lint--check-objects-by-regexp
              "(define-minor-mode\\s-"


### PR DESCRIPTION
Hi.

```
(defalias 'foobar 'string-equal)
```

warns "Aliases should start with the package's prefix \"package-lint\". (emacs-lisp-package)".

On the other hand,

```
(define-obsolete-function-alias 'foobar 'string-equal)
```

generates

```
(progn
  (defalias 'foobar 'string-equal nil)
  (make-obsolete 'foobar 'string-equal nil))
```

but no warnings.
I think this macro should define alias with prefix.  How about think?