### PR TITLE
`package-lint--check-objects-by-regexp`: conses

### DIFF
--- a/package-lint.el
+++ b/package-lint.el
@@ -1147,7 +1147,8 @@ otherwise invalid read forms are ignored."
       (let ((obj (unless (package-lint--inside-comment-or-string-p)
                    (save-excursion
                      (ignore-errors (read (current-buffer)))))))
-        (when obj (funcall function obj))))))
+        (when (and obj (listp (cdr-safe obj)))
+          (funcall function obj))))))
 
 
 ;;; Public interface


### PR DESCRIPTION
The former function now only calls FUNCTION if the sexp it found is not
a cons whose `cdr' is not a list.

Fixes #196.