### PR TITLE
Test defface symbol contains a non-standard separator

### DIFF
--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -448,9 +448,15 @@ Alternatively, depend on (emacs \"24.3\") or greater, in which cl-lib is bundled
   (should
    (equal
     '((6 0 error "`test-thing/bar' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions).")
-      (7 0 error "`test-thing:bar' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions)."))
+      (7 0 error "`test-thing:bar' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions).")
+      (8 0 error "`test-thing:face' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions).")
+      (9 0 error "`test-thing/face' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions)."))
     (package-lint-test--run
-     "(defun test-thing/bar () t)\n(defun test-thing:bar () nil)")))
+     "\
+(defun test-thing/bar () t)
+(defun test-thing:bar () nil)
+(defface test-thing:face '((default)))
+(defface test-thing/face '((default)))")))
   ;; But accept /= when at the end.
   (should (equal '() (package-lint-test--run "(defun test-/= (a b) t)"))))
 

--- a/package-lint.el
+++ b/package-lint.el
@@ -1126,7 +1126,7 @@ The returned list is of the form (SYMBOL-NAME . POSITION)."
       (pcase entry
         ((and `(,submenu-name . ,submenu-elements)
               (guard (consp submenu-elements)))
-         (when (member submenu-name '("Variables" "Defuns"))
+         (when (member submenu-name '("Variables" "Defuns" "Types"))
            (setq result (nconc (reverse submenu-elements) result))))
         (_
          (push entry result))))


### PR DESCRIPTION
Test defface symbol contains a non-standard separator.
If this PR merged, `package-lint` will start test `defface` symbol
contains a non-standard separator.

Please see testfile to find more concrete examples.

### Note:
As a side-effect, `package-lint` will check below symbols that matches
below regexp
```elisp
   (list (purecopy "Types")
	 (purecopy (concat "^\\s-*("
			   (eval-when-compile
			     (regexp-opt
			      '(;; Elisp
                                "defgroup" "deftheme"
                                "define-widget" "define-error"
				"defface" "cl-deftype" "cl-defstruct"
                                ;; CL
                                "deftype" "defstruct"
				"define-condition" "defpackage"
                                ;; CLOS and EIEIO
                                "defclass")
                              t))
			   "\\s-+'?\\(" lisp-mode-symbol-regexp "\\)"))
	 2)
```
https://github.com/emacs-mirror/emacs/blob/47f2a39f427f2e7bfd3de371316e3a2c47841340/lisp/emacs-lisp/lisp-mode.el#L139-L154