### PR TITLE
More accurate regexp for looks-like-a-package-p

### DIFF
--- a/package-lint.el
+++ b/package-lint.el
@@ -42,6 +42,7 @@
 (require 'imenu)
 (require 'let-alist)
 (require 'rx)
+(require 'regexp-opt)
 
 
 (defvar package-lint-main-file nil
@@ -1282,7 +1283,7 @@ whether or not warnings alone produce a non-zero exit code."
             (goto-char (point-min))
             (re-search-forward
              (concat lm-header-prefix
-                     (rx (or "Version" "Package-Version" "Package-Requires")))
+                     (regexp-opt '("Version:" "Package-Version:" "Package-Requires:")))
              nil t))))))
 
 (provide 'package-lint)


### PR DESCRIPTION
So when I turn on `flycheck-package`, and if I'm looking at my init.el that happens to have a section called `;; Version Control`, package-lint won't think I'm looking at a elisp package.