### PR TITLE
Consider define-advice forms to be global definitions

### DIFF
--- a/package-lint.el
+++ b/package-lint.el
@@ -915,7 +915,7 @@ Valid definition names are:
       (when position
         (goto-char position)
         (looking-at-p (rx (*? space) "(" (*? space)
-                          (or "defadvice" "cl-defmethod")
+                          (or "defadvice" "cl-defmethod" "define-advice")
                           symbol-end)))))
 
 (defun package-lint--check-defs-prefix (prefix definitions)


### PR DESCRIPTION
define-advice will define symbols that start with the name of the
function being advised, so they should be exempt from the package
prefix check.