### PR TITLE
Use save-match-data instead of obsolete inhibit-changing-match-data

### DIFF
--- a/package-lint.el
+++ b/package-lint.el
@@ -1059,7 +1059,7 @@ PREFIX is the package prefix."
 Lines consisting only of whitespace or empty comments are considered empty."
   (save-excursion
     (save-restriction
-      (let ((inhibit-changing-match-data t))
+      (save-match-data
         (narrow-to-region start end)
         (goto-char start)
         (while (and (looking-at "^[[:space:]]*;*[[:space:]]*$")


### PR DESCRIPTION
```
In package-lint--region-empty-p:
lib/package-lint/package-lint.el:1062:14: Warning:
    ‘inhibit-changing-match-data’ is an obsolete variable (as of 29.1); use
    ‘save-match-data’ instead.
```