### PR TITLE
Accept Package-Requires header without version

### DIFF
--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -255,10 +255,6 @@ headers and provide form."
 (ert-deftest package-lint-test-error-invalid-dependency ()
   (should
    (member
-    '(6 0 error "Expected (package-name \"version-num\"), but found invalid.")
-    (package-lint-test--run ";; Package-Requires: (invalid)")))
-  (should
-   (member
     '(6 23 error "\"invalid\" is not a valid version string: see `version-to-list'.")
     (package-lint-test--run ";; Package-Requires: ((package-lint \"invalid\"))"))))
 
@@ -291,6 +287,14 @@ headers and provide form."
     (package-lint-test--run ";; Package-Requires: ((package-lint \"20160101.1234\"))"))))
 
 (ert-deftest package-lint-test-warn-unversioned-dep ()
+  (should
+   (member
+    '(6 22 warning "Use a properly versioned dependency on \"package-lint\" if possible.")
+    (package-lint-test--run ";; Package-Requires: (package-lint)")))
+  (should
+   (member
+    '(6 23 warning "Use a properly versioned dependency on \"package-lint\" if possible.")
+    (package-lint-test--run ";; Package-Requires: ((package-lint))")))
   (should
    (equal
     '((6 23 warning "Use a properly versioned dependency on \"package-lint\" if possible."))

--- a/package-lint.el
+++ b/package-lint.el
@@ -452,8 +452,8 @@ the form (PACKAGE-NAME PACKAGE-VERSION DEP-POSITION)."
                             (re-search-forward symbol-pattern (line-end-position) t))
                         (match-beginning 1)
                       position)))))
-           (if (null package-version)
-               (setq package-version "0"))
+           (unless package-version
+             (setq package-version "0"))
            (if (ignore-errors (version-to-list package-version))
                (push (list package-name
                            (version-to-list package-version)


### PR DESCRIPTION
According to the manual, an entry in Package-Requires header may lack a version string.
An entry without a version is considered to have version "0".
https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html

So we should accept it.