### PR TITLE
look for installable packages from the correct places

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,6 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - 24.1
-          - 24.2
-          - 24.3
           - 24.4
           - 24.5
           - 25.1
@@ -35,10 +32,6 @@ jobs:
         include:
           - emacs_version: snapshot
             experimental: true
-          - emacs_version: 24.1
-            lint_ignore: 1
-          - emacs_version: 24.2
-            lint_ignore: 1
     env:
       EMACS_LINT_IGNORE: ${{ matrix.lint_ignore }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
         emacs_version:
           - 24.4

--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -281,6 +281,9 @@ headers and provide form."
     '((6 23 error "Package example-nonexistent-package is not installable."))
     (package-lint-test--run ";; Package-Requires: ((example-nonexistent-package \"1\"))"))))
 
+(ert-deftest package-lint-test-accept-builtin-dep ()
+  (should (equal '() (package-lint-test--run ";; Package-Requires: ((ediff \"2.0.0\"))"))))
+
 (ert-deftest package-lint-test-warn-snapshot-dep ()
   (should
    (equal

--- a/package-lint.el
+++ b/package-lint.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/purcell/package-lint
 ;; Keywords: lisp
 ;; Version: 0.18
-;; Package-Requires: ((cl-lib "0.5") (emacs "24.1") (let-alist "1.0.6"))
+;; Package-Requires: ((cl-lib "0.5") (emacs "24.4") (let-alist "1.0.6"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
`package-archive-contents` is empty until a `package-refresh-contents` and friends call is made to fetch from the archives, it also does not contain any builtin packages. This PR make `package-lint--check-packages-installable` look for the list of package descriptors from the builtins list, installed list and the archive cache.