### PR TITLE
Add use-package keyword definition prefixes to sane prefixes

### DIFF
--- a/package-lint.el
+++ b/package-lint.el
@@ -181,7 +181,10 @@ symbol such as `variable-added'.")
     "org-babel-prep-session:"
     "org-babel-variable-assignments:"
     "org-babel-default-header-args:"
-    "pcomplete/"))
+    "pcomplete/"
+    "use-package-normalize/"
+    "use-package-handler/"
+    "use-package-autoloads/"))
   "A regexp matching whitelisted non-standard symbol prefixes.")
 
 (defvar package-lint--allowed-prefix-mappings


### PR DESCRIPTION
Use-package requires using these prefixes to define new keywords.

Following up on discussion in #125.