### PR TITLE
Add org-babel-expand-body:

### DIFF
--- a/package-lint.el
+++ b/package-lint.el
@@ -193,6 +193,7 @@ TYPE is `function' or `variable'."
    (or
     "org-dblock-write:"
     "org-babel-execute:"
+    "org-babel-expand-body:"
     "org-babel-prep-session:"
     "org-babel-variable-assignments:"
     "org-babel-default-header-args:"


### PR DESCRIPTION
Hi, I would like to propose you adding `org-babel-expand-body:` for org-babel as the same as `org-babel-execute`.

Cheers.