### PR TITLE
Bump the emacs-head-version

### DIFF
--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -270,7 +270,7 @@ headers and provide form."
   (should
    (equal
     '((6 23 warning "This makes the package uninstallable in all released Emacs versions."))
-    (package-lint-test--run ";; Package-Requires: ((emacs \"30\"))"))))
+    (package-lint-test--run ";; Package-Requires: ((emacs \"31\"))"))))
 
 (ert-deftest package-lint-test-accept-emacs-24+-dep ()
   (should (equal '() (package-lint-test--run ";; Package-Requires: ((emacs \"24\"))")))

--- a/package-lint.el
+++ b/package-lint.el
@@ -86,7 +86,7 @@ The path can be absolute or relative to that of the linted file.")
   "List of errors and warnings for the current buffer.
 This is bound dynamically while the checks run.")
 
-(defconst package-lint-emacs-head-version '(30)
+(defconst package-lint-emacs-head-version '(31)
   "Version of Emacs HEAD.")
 
 (defconst package-lint-backport-libraries


### PR DESCRIPTION
Emacs 30 was released last month, so now the head version is 31.

I've noticed this problem when I tried running package-lint on a package requiring Emacs 30. 