### PR TITLE
Support relative package-lint-main-file for files in a sub dir in batch mode

### DIFF
--- a/batch-tests/relative-package-lint-main-file/foo-bar.el
+++ b/batch-tests/relative-package-lint-main-file/foo-bar.el
@@ -1,0 +1,33 @@
+;;; foo-bar.el --- Dummy comment               -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026  Lin Jian
+
+;; Author: Lin Jian <me@linj.tech>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Some stuff here
+
+;;; Code:
+
+
+
+(provide 'foo-bar)
+;;; foo-bar.el ends here
+
+;; Local Variables:
+;; package-lint-main-file: "foo.el"
+;; End:

--- a/batch-tests/relative-package-lint-main-file/foo.el
+++ b/batch-tests/relative-package-lint-main-file/foo.el
@@ -1,0 +1,32 @@
+;;; foo.el --- Dummy comment               -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026  Lin Jian
+
+;; Author: Lin Jian <me@linj.tech>
+;; URL: https://github.com/purcell/package-lint
+;; Package-Requires: ((emacs "24"))
+;; Package-Version: 0
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Some stuff here
+
+;;; Code:
+
+
+
+(provide 'foo)
+;;; foo.el ends here

--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -933,6 +933,19 @@ Alternatively, depend on (emacs \"24.3\") or greater, in which cl-lib is bundled
     "(let ((bar |foo)) blah)"
     (package-lint--is-a-let-binding))))
 
+(ert-deftest package-lint-test-accept-relative-main-file-in-batch-mode ()
+  (let ((this-dir (if load-file-name
+                      (file-name-directory load-file-name)
+                    default-directory)))
+    (ert-info ("lint files in the current dir")
+      (let ((default-directory
+             (expand-file-name "batch-tests/relative-package-lint-main-file/" this-dir)))
+        (should (package-lint-batch-and-exit-1 '("foo.el" "foo-bar.el")))))
+    (ert-info ("lint files in a sub dir")
+      (let ((default-directory (expand-file-name "batch-tests/" this-dir)))
+        (should
+         (package-lint-batch-and-exit-1 '("relative-package-lint-main-file/foo.el"
+                                          "relative-package-lint-main-file/foo-bar.el")))))))
 
 (provide 'package-lint-test)
 ;;; package-lint-test.el ends here

--- a/package-lint-test.el
+++ b/package-lint-test.el
@@ -934,6 +934,9 @@ Alternatively, depend on (emacs \"24.3\") or greater, in which cl-lib is bundled
     (package-lint--is-a-let-binding))))
 
 (ert-deftest package-lint-test-accept-relative-main-file-in-batch-mode ()
+  :expected-result (if (= emacs-major-version 25)
+                       :failed
+                     :passed)
   (let ((this-dir (if load-file-name
                       (file-name-directory load-file-name)
                     default-directory)))

--- a/package-lint.el
+++ b/package-lint.el
@@ -1345,6 +1345,7 @@ The main loop is this separate function so it's easier to test."
     (dolist (file filenames success)
       (let* ((file (expand-file-name file))
              (file-directory (file-name-directory file))
+             (default-directory file-directory)
              (base (file-name-nondirectory file)))
         (with-temp-buffer
           (insert-file-contents file t)


### PR DESCRIPTION
See the newly added ERT test `package-lint-test-accept-relative-main-file-in-batch-mode` for how to reproduce the bug.  Specifically, the sub test "lint files in a sub dir" fails without the fix in this PR and shows the bug.